### PR TITLE
fix: date functions with NOW() does not work in Firefox

### DIFF
--- a/src/61date.js
+++ b/src/61date.js
@@ -50,9 +50,9 @@ stdfn.NOW = function () {
 	var d = new Date();
 	var s =
 		d.getFullYear() +
-		'.' +
+		'-' +
 		('0' + (d.getMonth() + 1)).substr(-2) +
-		'.' +
+		'-' +
 		('0' + d.getDate()).substr(-2);
 	s +=
 		' ' +


### PR DESCRIPTION
Thank you for the time you are putting into AlaSQL!


