### PR TITLE
Fix: newDate() in Safari (et. al.)

### DIFF
--- a/src/61date.js
+++ b/src/61date.js
@@ -166,12 +166,24 @@ alasql.stdfn.DATE_SUB = alasql.stdfn.SUBDATE = function (d, interval) {
 	return new Date(nd);
 };
 
-var dateRegexp = /^\d{4}\.\d{2}\.\d{2} \d{2}:\d{2}:\d{2}/;
+var dateRegexp = /^(?<year>\d{4})[-\.](?<month>\d{1,2})[-\.](?<day>\d{1,2})( (?<hours>\d{2}):(?<minutes>\d{2})(:(?<seconds>\d{2})(\.(?<milliseconds>)\d{3})?)?)?/;
 function newDate(d) {
-	if (typeof d === 'string') {
-		if (dateRegexp.test(d)) {
-			d = d.replace('.', '-').replace('.', '-');
+	let date = new Date(d);
+
+	if (isNaN(date)) {
+		if (typeof d === 'string') {
+			const match = d.match(dateRegexp);
+			if (match) {
+				const { year, month, day, hours, minutes, seconds, milliseconds } = match.groups;
+				const dateArrguments = [year, month - 1, day];
+				if (hours) {
+					dateArrguments.push(hours, minutes, seconds || 0, milliseconds || 0);
+				}
+
+				date = new Date(...dateArrguments);
+			}
 		}
 	}
-	return new Date(d);
+
+	return date;
 }


### PR DESCRIPTION
Supported formats:
"2022.01.10 04:10",
"2022.01.10 04:10:11",
"2022.01.10 04:10:11.123",
"2022-01-10 04:10",
"2022-01-10 04:10:11",
"2022-01-10 04:10:11.123",
"2022.1.10",
"2022-1-1"
...


